### PR TITLE
converting ilias lm objects to use _blank on internal links

### DIFF
--- a/Modules/LearningModule/Presentation/classes/class.ilLMPresentationLinker.php
+++ b/Modules/LearningModule/Presentation/classes/class.ilLMPresentationLinker.php
@@ -384,7 +384,10 @@ class ilLMPresentationLinker implements \ILIAS\COPage\PageLinker
                                 if ($showViewInFrameset) {
                                     $ltarget = "_parent";
                                 } else {
-                                    $ltarget = "_top";
+                                    // START PATCH JKN
+                                    //$ltarget = "_top";
+                                    $ltarget = "_blank";
+                                    // END PATCH JKN
                                 }
                             }
                             // scorm always in 1window view and link target
@@ -477,7 +480,11 @@ class ilLMPresentationLinker implements \ILIAS\COPage\PageLinker
                         } else {
                             $href = ILIAS_HTTP_PATH . "/goto.php?target=" . $obj_type . "_" . $target_id . "&amp;client_id=" . CLIENT_ID;
                         }
-                        $ltarget = ilFrameTargetInfo::_getFrame("MainContent");
+                        // START PATCH JKN
+                        //$ltarget = ilFrameTargetInfo::_getFrame("MainContent");
+                        $ltarget = $nframe = "_blank";
+                        // END PATCH JKN
+
                         if ($this->embed_mode) {
                             $ltarget = "_blank";
                         }

--- a/Modules/LearningModule/classes/class.ilLMPageObjectGUI.php
+++ b/Modules/LearningModule/classes/class.ilLMPageObjectGUI.php
@@ -293,7 +293,11 @@ class ilLMPageObjectGUI extends ilLMObjectGUI
                         $obj_id = ilObject::_lookupObjId($target_id);
                         $href = "./goto.php?target=" . $obj_type . "_" . $target_id;
                         $t_frame = ilFrameTargetInfo::_getFrame("MainContent", $obj_type);
-                        $ltarget = $t_frame;
+                        
+                        // START PATCH JKN
+                        //$ltarget = $t_frame;
+                        $ltarget = $nframe = "_blank";
+                        // END PATCH JKN
                         break;
 
                     case "File":


### PR DESCRIPTION
A request previously from a client at ENV. This makes it so Ilias Learning Modules open "Internal" links as new tabs.