### PR TITLE
SVG Hotfix - Removes check for base64 encoded content.

### DIFF
--- a/src/FileUpload/Processor/SVGBlacklistPreProcessor.php
+++ b/src/FileUpload/Processor/SVGBlacklistPreProcessor.php
@@ -193,13 +193,6 @@ final class SVGBlacklistPreProcessor implements PreProcessor
 
     private function hasContentScriptTag(string $raw_svg_content) : bool
     {
-        // Check for Base64 encoded Content
-        if (preg_match(self::REGEX_BASE64, $raw_svg_content)) {
-            $this->rejection_message = $this->rejection_message
-                . ' (base64).';
-            return true;
-        }
-
         // Check for script tags directly
         if (preg_match(self::REGEX_SCRIPT, $raw_svg_content)) {
             $this->rejection_message = $this->rejection_message


### PR DESCRIPTION
Essentially, clients are using online SVG converters to convert pngs to svgs, but it is just encoding pngs into Base64, and then embeds this data string into an SVG.

This method does not create genuine SVGs. Although these files may seem operational for uploading purposes, they do not possess the scalability of true SVGs, as they are essentially encoded PNGs in disguise.

Furthermore, the LMS has ramped up its security measures, which now scrutinize the upload of data via SVG files due to the inability to determine whether the embedded data poses any security risk.

Since we're checking the SVG's for script tags already, this should realistically be enough. Only portal administrators can upload custom icons as well, so the combo of those should be enough.