### PR TITLE
Fixes query parser for quotes in the search

### DIFF
--- a/Services/Search/classes/class.ilQueryParser.php
+++ b/Services/Search/classes/class.ilQueryParser.php
@@ -160,7 +160,7 @@ class ilQueryParser
             return $this->quoted_words ? $this->quoted_words : array();
         } else {
             foreach ($this->quoted_words as $word) {
-                $tmp_word[] = str_replace("\"", '', $word);
+                $tmp_word[] = str_replace('\"', '', $word);
             }
             return $tmp_word ? $tmp_word : array();
         }


### PR DESCRIPTION
the double quotes here messed this search up when you searched something like "Test" from the dropdown in search, lots of back and forth in the Ilias mantis about how this fix didn't work for 7 that they applied for 8, so I reverted and tested and everything works great now.

https://taiga.cpkn.ca/project/kathy-tasks-and-issues-april-2023-march-2024/issue/843