### PR TITLE
Update class.ilContainerSorting.php

### DIFF
--- a/Services/Container/classes/class.ilContainerSorting.php
+++ b/Services/Container/classes/class.ilContainerSorting.php
@@ -407,7 +407,7 @@ class ilContainerSorting
         }
         $items = [];
         foreach ($a_type_positions as $key => $position) {
-            if ($key == "blocks") {
+            if ($key === "blocks") {
                 $this->saveBlockPositions($position);
             } elseif (!is_array($position)) {
                 $items[$key] = ((float) $position) * 100;


### PR DESCRIPTION
Changes comparison on sorting save to be === vs == as there is some strangeness in php 7.4 where 0 == "blocks" is correct.