### PR TITLE
Lp hotfix ilias lm

### DIFF
--- a/Modules/LearningModule/classes/class.ilLMPageObject.php
+++ b/Modules/LearningModule/classes/class.ilLMPageObject.php
@@ -632,7 +632,8 @@ class ilLMPageObject extends ilLMObject
         $a_order_field,
         $a_order_dir,
         $a_offset,
-        $a_limit
+        $a_limit,
+        $a_lang = '-'
     ) {
         global $DIC;
 
@@ -651,16 +652,9 @@ class ilLMPageObject extends ilLMObject
         " AND pq.page_id = t.child and pq.page_parent_type = " . $ilDB->quote("lm", "text") . ") " .
         "WHERE t.lm_id = " . $ilDB->quote($a_lm_id, "integer") . " AND pq.page_lang = " . $ilDB->quote($a_lang, "text");
 
-        $ot = ilObjectTranslation::getInstance($a_lm_id);
-        $languages = $ot->getLanguages();
-        if ($a_lang != "-" && $ot->getContentActivated() && isset($languages[$a_lang])) {
-            " AND pq.page_lang = " . $ilDB->quote($a_lang, "text");
-        }
         // JKN PATCH END
         $count_query .= $from;
         $query .= $from;
-
-
         // count query
         $set = $ilDB->query($count_query);
         $cnt = 0;

--- a/Modules/LearningModule/classes/class.ilLMTracker.php
+++ b/Modules/LearningModule/classes/class.ilLMTracker.php
@@ -366,9 +366,14 @@ class ilLMTracker
         }
 
         // load question/pages information
-        $this->page_questions = array();
-        $this->all_questions = array();
-        $q = ilLMPageObject::queryQuestionsOfLearningModule($this->lm_obj_id, "", "", 0, 0);
+        $lang = $this->lng->getDefaultLanguage() === $this->user->getLanguage() ? '-' : $this->user->getLanguage();
+
+        $q = ilLMPageObject::queryQuestionsOfLearningModule($this->lm_obj_id, "", "", 0, 0, $lang);
+        //if not questions in users language (no page, go back to default.)
+        if(!$q){
+            $q = ilLMPageObject::queryQuestionsOfLearningModule($this->lm_obj_id, "", "", 0, 0);
+        }
+
         foreach ($q["set"] as $quest) {
             $this->page_questions[$quest["page_id"]][] = $quest["question_id"];
             $this->all_questions[] = $quest["question_id"];

--- a/Modules/LearningModule/classes/class.ilLMTracker.php
+++ b/Modules/LearningModule/classes/class.ilLMTracker.php
@@ -366,9 +366,14 @@ class ilLMTracker
         }
 
         // load question/pages information
+        $this->page_questions = array();
+        $this->all_questions = array();
+
+        // load question/pages information
         $lang = $this->lng->getDefaultLanguage() === $this->user->getLanguage() ? '-' : $this->user->getLanguage();
 
         $q = ilLMPageObject::queryQuestionsOfLearningModule($this->lm_obj_id, "", "", 0, 0, $lang);
+        
         //if not questions in users language (no page, go back to default.)
         if(!$q){
             $q = ilLMPageObject::queryQuestionsOfLearningModule($this->lm_obj_id, "", "", 0, 0);


### PR DESCRIPTION
when determining LP on the whole of an ilias learning module set to 'all answers answered correctly' the backend was not determining the users language, so it'd get an array of ALL questions in the learning module regardless of language, and see they had not answered all of them.

This only returns questions for the users language settings.