### PR TITLE
Gradebook hotfix for subtab.

### DIFF
--- a/Services/Tracking/classes/class.ilLearningProgressBaseGUI.php
+++ b/Services/Tracking/classes/class.ilLearningProgressBaseGUI.php
@@ -251,45 +251,47 @@ class ilLearningProgressBaseGUI
                                 $a_active == self::LP_ACTIVE_MATRIX
                             );
                         }
+                    }
 
-                        // START PATCH JKN GRADEBOOK
-                        if ($olp->getCurrentMode() == 93) {
-                            include_once 'Modules/Course/classes/class.ilCourseParticipants.php';
-                            global $ilUser;
-                            //if the user is a course admin or course tutor give them
-                            // the weight and course particpants subtab.
-                            $crs_members = ilCourseParticipants::_getInstanceByObjId($this->getObjId());
-                            if ($crs_members->isAdmin($ilUser->getId()) || $crs_members->isTutor($ilUser->getId())) {
-                                //weighting view
-                                $this->tabs_gui->addSubTabTarget(
-                                    "trac_gradebook",
-                                    $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", 'showGradebookWeight'),
-                                    "",
-                                    "",
-                                    "",
-                                    $a_active == self::LP_ACTIVE_GRADEBOOK
-                                );
-                            }
+                    // START PATCH JKN GRADEBOOK
+                    if ($olp->getCurrentMode() == 93) {
+                        include_once 'Modules/Course/classes/class.ilCourseParticipants.php';
+                        global $ilUser;
+                        //if the user is a course admin or course tutor give them
+                        // the weight and course particpants subtab.
+                        $crs_members = ilCourseParticipants::_getInstanceByObjId($this->getObjId());
+                        
+                        if ($crs_members->isAdmin($ilUser->getId()) || $crs_members->isTutor($ilUser->getId())) {
+                            //weighting view
                             $this->tabs_gui->addSubTabTarget(
-                                "trac_gradebook_gradebystudent",
-                                $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", 'showGradebookStudentGrade'),
+                                "trac_gradebook",
+                                $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", 'showGradebookWeight'),
                                 "",
                                 "",
                                 "",
-                                $a_active == self::LP_ACTIVE_GRADEBYSTUDENT
-                            );
-                        } else {
-                            $this->tabs_gui->addSubTabTarget(
-                                "trac_summary",
-                                $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", 'showObjectSummary'),
-                                "",
-                                "",
-                                "",
-                                $a_active == self::LP_ACTIVE_SUMMARY
+                                $a_active == self::LP_ACTIVE_GRADEBOOK
                             );
                         }
-                        // END PATCH GRADEBOOK CPKN
+                        $this->tabs_gui->addSubTabTarget(
+                            "trac_gradebook_gradebystudent",
+                            $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", 'showGradebookStudentGrade'),
+                            "",
+                            "",
+                            "",
+                            $a_active == self::LP_ACTIVE_GRADEBYSTUDENT
+                        );
+                    } else {
+                        $this->tabs_gui->addSubTabTarget(
+                            "trac_summary",
+                            $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", 'showObjectSummary'),
+                            "",
+                            "",
+                            "",
+                            $a_active == self::LP_ACTIVE_SUMMARY
+                        );
                     }
+                    // END PATCH GRADEBOOK CPKN
+                    
                 }
                 include_once './Services/Tracking/classes/class.ilLearningProgressAccess.php';
                 if (!($olp instanceof ilPluginLP) &&


### PR DESCRIPTION
A missplaced end bracket which should have ended with hiding the Matrix View when Gradebook was selected was hiding all Gradebook tabs, moved the logic and now tabs show up as intended.