### PR TITLE
Only recalculates actively edited users score on manual score editing

### DIFF
--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -85,15 +85,17 @@ class ilTestScoring
     public function recalculateSolutions($activeId = null)
     {
         $participants = $this->test->getCompleteEvaluationData(false)->getParticipants();
+
+        //if activeId was sent in, filter the array down to just that participant. 
+        $participants = $activeId ? [$activeId => $participants[$activeId]] : $participants;
+
         if (is_array($participants)) {
             require_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
             foreach ($participants as $active_id => $userdata) {
-                if($active_id === $activeId) {
-                    if (is_object($userdata) && is_array($userdata->getPasses())) {
-                        $this->recalculatePasses($userdata, $active_id);
-                     }
-                     assQuestion::_updateTestResultCache($active_id);
+                if (is_object($userdata) && is_array($userdata->getPasses())) {
+                    $this->recalculatePasses($userdata, $active_id);
                 }
+                assQuestion::_updateTestResultCache($active_id);
             }
         }
     }

--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -75,16 +75,25 @@ class ilTestScoring
         $this->questionId = $questionId;
     }
     
-    public function recalculateSolutions()
+    /**
+     * Recalculates all solutions for all users / test passes.
+     * if $activeId is passed only recalculates soluations for specified active_id user.
+     *
+     * @param [type] $activeId
+     * @return void
+     */
+    public function recalculateSolutions($activeId = null)
     {
         $participants = $this->test->getCompleteEvaluationData(false)->getParticipants();
         if (is_array($participants)) {
             require_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
             foreach ($participants as $active_id => $userdata) {
-                if (is_object($userdata) && is_array($userdata->getPasses())) {
-                    $this->recalculatePasses($userdata, $active_id);
+                if($active_id === $activeId) {
+                    if (is_object($userdata) && is_array($userdata->getPasses())) {
+                        $this->recalculatePasses($userdata, $active_id);
+                     }
+                     assQuestion::_updateTestResultCache($active_id);
                 }
-                assQuestion::_updateTestResultCache($active_id);
             }
         }
     }

--- a/Modules/Test/classes/class.ilTestScoringGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringGUI.php
@@ -350,7 +350,8 @@ class ilTestScoringGUI extends ilTestServiceGUI
         require_once './Modules/Test/classes/class.ilTestScoring.php';
         $scorer = new ilTestScoring($this->object);
         $scorer->setPreserveManualScores(true);
-        $scorer->recalculateSolutions();
+        //recalculate the solutions for this users test to update the result cache.
+        $scorer->recalculateSolutions($activeId);
         
         if ($this->object->getAnonymity() == 0) {
             $user_name = ilObjUser::_lookupName(ilObjTestAccess::_getParticipantId($activeId));


### PR DESCRIPTION
Currently when you are manually scoring a user in a test currently the system goes through every other user's tests (and all of their passes of the test) and also manually rescores them even though nothing has changed.

My best guess is that it was a bug from reusing code intended to be used for updating a questions points value after the fact (the only other place recalculateSolutions is ever called)

This adds an option activeId variable to the recalculateSolutions, $activeId is the current active pass of a user through a test (comes from tst_active)

If this is passed (from when you're manually scoring a single user), the system will only manually recalculate this persons grades now.