### PR TITLE
calling iconv in sort_func only when value is string

### DIFF
--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -3026,8 +3026,13 @@ class ilUtil
         }
 
         // JKN PATCH START
-        $a[$array_sortby] = iconv('UTF-8', 'ASCII//TRANSLIT', $a[$array_sortby]);
-        $b[$array_sortby] = iconv('UTF-8', 'ASCII//TRANSLIT', $b[$array_sortby]);
+        if (is_string($a[$array_sortby])) {
+            $a[$array_sortby] = iconv('UTF-8', 'ASCII//TRANSLIT', $a[$array_sortby]);
+        }
+
+        if (is_string($b[$array_sortby])) {
+            $b[$array_sortby] = iconv('UTF-8', 'ASCII//TRANSLIT', $b[$array_sortby]);
+        }
         // JKN PATCH END
 
         // this comparison should give optimal results if


### PR DESCRIPTION
Fix for taiga ticket https://taiga.cpkn.ca/project/evanjackson-tasks-and-issues-april-2024-march-2025/issue/448.

Sorting a table by a column that contained an array of values resulted in an error.  Now only calling iconv method if the value is a string.