### PR TITLE
Hide summary tab from course members

### DIFF
--- a/Services/Tracking/classes/class.ilLearningProgressBaseGUI.php
+++ b/Services/Tracking/classes/class.ilLearningProgressBaseGUI.php
@@ -281,14 +281,16 @@ class ilLearningProgressBaseGUI
                             $a_active == self::LP_ACTIVE_GRADEBYSTUDENT
                         );
                     } else {
-                        $this->tabs_gui->addSubTabTarget(
-                            "trac_summary",
-                            $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", 'showObjectSummary'),
-                            "",
-                            "",
-                            "",
-                            $a_active == self::LP_ACTIVE_SUMMARY
-                        );
+                        if ($has_read) {
+                            $this->tabs_gui->addSubTabTarget(
+                                "trac_summary",
+                                $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", 'showObjectSummary'),
+                                "",
+                                "",
+                                "",
+                                $a_active == self::LP_ACTIVE_SUMMARY
+                            );
+                        }
                     }
                     // END PATCH GRADEBOOK CPKN
                     


### PR DESCRIPTION
Currently if you're not in an LP type of Gradebook (93), everyone gets the active tab 'Summary' in Learning Progress. Course Members were never intended to see this tab. It appears to be corrected by checking if they can read LP