### PR TITLE
Course reference copy was never adding ut_lp_settings in table

### DIFF
--- a/Modules/CourseReference/classes/class.ilObjCourseReference.php
+++ b/Modules/CourseReference/classes/class.ilObjCourseReference.php
@@ -157,9 +157,24 @@ class ilObjCourseReference extends ilContainerReference
      */
     public function cloneObject($a_target_id, $a_copy_id = 0, $a_omit_tree = false)
     {
+        global $DIC;
+        $ilLog = $DIC["ilLog"];
+        include_once('Services/Tracking/classes/class.ilLPObjSettings.php');
+
+        $ilLog->write("ilObjCourseReference::cloneObject(), start");
+        
         $new_obj = parent::cloneObject($a_target_id, $a_copy_id, $a_omit_tree);
         $new_obj->enableMemberUpdate($this->isMemberUpdateEnabled());
         $new_obj->update();
+        $newID = $new_obj->getId();
+
+        $id = $this->getId();
+        $ilLog->write("ilObjCourseReference::cloneObject(), Copying id settings:");
+        $ilLog->write($id);
+
+        $obj_settings = new ilLPObjSettings($id);
+        $obj_settings->cloneSettings($newID);
+        $ilLog->write("ilObjCourseReference::cloneObject(), Finishing.");
         return $new_obj;
     }
 }

--- a/Services/Tracking/classes/class.ilLPObjSettings.php
+++ b/Services/Tracking/classes/class.ilLPObjSettings.php
@@ -203,9 +203,7 @@ class ilLPObjSettings
     public function cloneSettings($a_new_obj_id)
     {
         global $DIC;
-        $ilLog = $DIC["ilLog"];
-        $ilDB = $DIC['ilDB'];
-        $ilLog->write("ilLPObjSettings::cloneSettings(), starting");
+        $il = $DIC["il"];
 
         $query = "INSERT INTO ut_lp_settings (obj_id,obj_type,u_mode,visits) " .
             "VALUES( " .
@@ -215,7 +213,6 @@ class ilLPObjSettings
             $this->db->quote($this->getVisits(), 'integer') .
             ")";
         $res = $ilDB->manipulate($query);
-        $ilLog->write("ilLPObjSettings::cloneSettings(), finishing");
         return true;
     }
 

--- a/Services/Tracking/classes/class.ilLPObjSettings.php
+++ b/Services/Tracking/classes/class.ilLPObjSettings.php
@@ -203,6 +203,7 @@ class ilLPObjSettings
     public function cloneSettings($a_new_obj_id)
     {
         global $DIC;
+        
         $ilDB = $DIC['ilDB'];
 
         $query = "INSERT INTO ut_lp_settings (obj_id,obj_type,u_mode,visits) " .

--- a/Services/Tracking/classes/class.ilLPObjSettings.php
+++ b/Services/Tracking/classes/class.ilLPObjSettings.php
@@ -203,7 +203,7 @@ class ilLPObjSettings
     public function cloneSettings($a_new_obj_id)
     {
         global $DIC;
-        $il = $DIC["il"];
+        $il = $DIC["ilDB"];
 
         $query = "INSERT INTO ut_lp_settings (obj_id,obj_type,u_mode,visits) " .
             "VALUES( " .
@@ -288,7 +288,6 @@ class ilLPObjSettings
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
-
         $query = "INSERT INTO ut_lp_settings (obj_id,obj_type,u_mode,visits) " .
             "VALUES(" .
             $ilDB->quote($this->getObjId(), 'integer') . ", " .

--- a/Services/Tracking/classes/class.ilLPObjSettings.php
+++ b/Services/Tracking/classes/class.ilLPObjSettings.php
@@ -203,7 +203,7 @@ class ilLPObjSettings
     public function cloneSettings($a_new_obj_id)
     {
         global $DIC;
-        $il = $DIC["ilDB"];
+        $ilDB = $DIC['ilDB'];
 
         $query = "INSERT INTO ut_lp_settings (obj_id,obj_type,u_mode,visits) " .
             "VALUES( " .
@@ -287,7 +287,9 @@ class ilLPObjSettings
     public function insert()
     {
         global $DIC;
+        
         $ilDB = $DIC['ilDB'];
+        
         $query = "INSERT INTO ut_lp_settings (obj_id,obj_type,u_mode,visits) " .
             "VALUES(" .
             $ilDB->quote($this->getObjId(), 'integer') . ", " .

--- a/Services/Tracking/classes/class.ilLPObjSettings.php
+++ b/Services/Tracking/classes/class.ilLPObjSettings.php
@@ -203,7 +203,7 @@ class ilLPObjSettings
     public function cloneSettings($a_new_obj_id)
     {
         global $DIC;
-        
+
         $ilDB = $DIC['ilDB'];
 
         $query = "INSERT INTO ut_lp_settings (obj_id,obj_type,u_mode,visits) " .
@@ -288,9 +288,9 @@ class ilLPObjSettings
     public function insert()
     {
         global $DIC;
-        
+
         $ilDB = $DIC['ilDB'];
-        
+
         $query = "INSERT INTO ut_lp_settings (obj_id,obj_type,u_mode,visits) " .
             "VALUES(" .
             $ilDB->quote($this->getObjId(), 'integer') . ", " .

--- a/Services/Tracking/classes/class.ilLPObjSettings.php
+++ b/Services/Tracking/classes/class.ilLPObjSettings.php
@@ -203,8 +203,9 @@ class ilLPObjSettings
     public function cloneSettings($a_new_obj_id)
     {
         global $DIC;
-
+        $ilLog = $DIC["ilLog"];
         $ilDB = $DIC['ilDB'];
+        $ilLog->write("ilLPObjSettings::cloneSettings(), starting");
 
         $query = "INSERT INTO ut_lp_settings (obj_id,obj_type,u_mode,visits) " .
             "VALUES( " .
@@ -214,6 +215,7 @@ class ilLPObjSettings
             $this->db->quote($this->getVisits(), 'integer') .
             ")";
         $res = $ilDB->manipulate($query);
+        $ilLog->write("ilLPObjSettings::cloneSettings(), finishing");
         return true;
     }
 
@@ -288,7 +290,6 @@ class ilLPObjSettings
     public function insert()
     {
         global $DIC;
-
         $ilDB = $DIC['ilDB'];
 
         $query = "INSERT INTO ut_lp_settings (obj_id,obj_type,u_mode,visits) " .


### PR DESCRIPTION
There was a core issue with the LP from course references never getting created in ut_lp_settings table on clone. 