### PR TITLE
check for lang on title variable in header for page layout

### DIFF
--- a/Modules/SystemFolder/classes/class.ilObjSystemFolder.php
+++ b/Modules/SystemFolder/classes/class.ilObjSystemFolder.php
@@ -180,10 +180,14 @@ class ilObjSystemFolder extends ilObject
             $title = (string) $row->title;
         }
 
+        $language = isset($_GET['lang']) && trim($_GET['lang']) !== ''
+            ? strtolower(trim((string) $_GET['lang']))
+            : $ilUser->getCurrentLanguage();
+
         $q = "SELECT title FROM object_translation " .
             "WHERE obj_id = " . $ilDB->quote($id, 'integer') . " " .
             "AND lang_code = " .
-            $ilDB->quote($ilUser->getCurrentLanguage(), 'text') . " " .
+            $ilDB->quote($language, 'text') . " " .
             "AND NOT lang_default = 1";
         $r = $ilDB->query($q);
         $row = $ilDB->fetchObject($r);


### PR DESCRIPTION
check for system lang instead of users on header title so on login page it respects the lang setting

https://taiga.cpkn.ca/project/evanjackson-tasks-and-issues-april-2024-march-2025/issue/1136

This was noticed when we added a FR head title for RCMP and it didnt respect the inputted lang on the login as it checks specifically for what the user is set to and the user is not logged in yet